### PR TITLE
Task 4166 Remove protected_attributes gem from dependencies

### DIFF
--- a/enum_state_machine.gemspec
+++ b/enum_state_machine.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 4.0", "< 4.2"
 
   s.add_dependency "activerecord-deprecated_finders", "~> 1.0.3"
-  s.add_dependency "protected_attributes", "~> 1.0.7"
   #s.add_dependency "rails-observers", "~> 0.1.2"
   s.add_dependency "power_enum", "~> 2.7"
 


### PR DESCRIPTION
Task 4166 - Remove protected_attributes gem  from dependencies of enum_state_machine


### Tests
```
1831 runs, 2228 assertions, 0 failures, 0 errors, 0 skips
```
