### PR TITLE
Fix for Rails 6 frozen hash

### DIFF
--- a/lib/enum_state_machine/integrations/active_record.rb
+++ b/lib/enum_state_machine/integrations/active_record.rb
@@ -456,7 +456,7 @@ module EnumStateMachine
           define_helper :class, <<-end_eval, __FILE__, __LINE__ + 1
             def column_defaults(*) #:nodoc:
               super
-              @column_defaults = _default_attributes.dup.to_hash
+              @column_defaults = _default_attributes.deep_dup.to_hash
               # No need to pass in an object, since the overrides will be forced
               self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => @column_defaults)
               @column_defaults.tap do |hash|

--- a/lib/enum_state_machine/integrations/active_record.rb
+++ b/lib/enum_state_machine/integrations/active_record.rb
@@ -455,9 +455,10 @@ module EnumStateMachine
           # attributes passed into #initialize
           define_helper :class, <<-end_eval, __FILE__, __LINE__ + 1
             def column_defaults(*) #:nodoc:
-              result = super
+              super
+              result = _default_attributes.dup.to_hash
               # No need to pass in an object, since the overrides will be forced
-              self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => result.deep_dup)
+              self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => result)
               result
             end
           end_eval

--- a/lib/enum_state_machine/integrations/active_record.rb
+++ b/lib/enum_state_machine/integrations/active_record.rb
@@ -455,12 +455,11 @@ module EnumStateMachine
           # attributes passed into #initialize
           define_helper :class, <<-end_eval, __FILE__, __LINE__ + 1
             def column_defaults(*) #:nodoc:
-              super
-              @column_defaults = _default_attributes.deep_dup.to_hash
-              # No need to pass in an object, since the overrides will be forced
-              self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => @column_defaults)
-              @column_defaults.tap do |hash|
-                hash.freeze if Rails::VERSION::MAJOR >= 6
+              @column_defaults = super.tap do |defaults|
+                @column_defaults_unfrozen ||= defaults.frozen? ? defaults.deep_dup : defaults
+
+                # No need to pass in an object, since the overrides will be forced
+                self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => @column_defaults_unfrozen)
               end
             end
           end_eval

--- a/lib/enum_state_machine/integrations/active_record.rb
+++ b/lib/enum_state_machine/integrations/active_record.rb
@@ -457,7 +457,7 @@ module EnumStateMachine
             def column_defaults(*) #:nodoc:
               result = super
               # No need to pass in an object, since the overrides will be forced
-              self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => result)
+              self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => result.deep_dup)
               result
             end
           end_eval

--- a/lib/enum_state_machine/integrations/active_record.rb
+++ b/lib/enum_state_machine/integrations/active_record.rb
@@ -456,10 +456,12 @@ module EnumStateMachine
           define_helper :class, <<-end_eval, __FILE__, __LINE__ + 1
             def column_defaults(*) #:nodoc:
               super
-              result = _default_attributes.dup.to_hash
+              @column_defaults = _default_attributes.dup.to_hash
               # No need to pass in an object, since the overrides will be forced
-              self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => result)
-              result
+              self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => @column_defaults)
+              @column_defaults.tap do |hash|
+                hash.freeze if Rails::VERSION::MAJOR >= 6
+              end
             end
           end_eval
         end

--- a/lib/enum_state_machine/integrations/active_record.rb
+++ b/lib/enum_state_machine/integrations/active_record.rb
@@ -455,12 +455,17 @@ module EnumStateMachine
           # attributes passed into #initialize
           define_helper :class, <<-end_eval, __FILE__, __LINE__ + 1
             def column_defaults(*) #:nodoc:
-              @column_defaults = super.tap do |defaults|
-                @column_defaults_unfrozen ||= defaults.frozen? ? defaults.deep_dup : defaults
+              @column_defaults = super
+              return @column_defaults if @column_defaults_are_set
+              @column_defaults_are_set = true
 
-                # No need to pass in an object, since the overrides will be forced
-                self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => @column_defaults_unfrozen)
-              end
+              was_frozen = @column_defaults.frozen?
+              @column_defaults = @column_defaults.deep_dup if was_frozen
+
+              # No need to pass in an object, since the overrides will be forced
+              self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => @column_defaults)
+
+              @column_defaults.tap { |defaults| defaults.freeze if was_frozen }
             end
           end_eval
         end


### PR DESCRIPTION
In Rails 6, [`ActiveRecord::Base#column_defaults`](https://github.com/rails/rails/blob/v6.1.4.4/activerecord/lib/active_record/model_schema.rb#L456) returns a frozen hash. Down the road from the spot where the changes occur in this PR, `options[:to]` is modified in-place in [`EnumStateMachine::Machine#initialize_state`](https://github.com/HornsAndHooves/enum_state_machine/blob/v0.6.0/lib/enum_state_machine/machine.rb#L704-L705).