### PR TITLE
DEV-17924: allow compatibility with Rails 7

### DIFF
--- a/enum_state_machine.gemspec
+++ b/enum_state_machine.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = %w(README.md CHANGELOG.md LICENSE)
   s.license           = 'MIT'
 
-  s.add_dependency "rails", ">= 6.0", "< 7.0"
+  s.add_dependency "rails", ">= 6.0"
   s.add_dependency "activerecord-deprecated_finders", ">= 1.0.3"
   #s.add_dependency "rails-observers", ">= 0.1.2"
-  s.add_dependency "power_enum", "> 2.8", "< 4.0"
+  s.add_dependency "power_enum", "> 2.8"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest", "~> 5.1"


### PR DESCRIPTION
[DEV-17924]

## Description
enum_state_machine works fine with Rails 7. There is no need for the restriction in the gemspec.

## Related Pull Requests

* Relates to https://github.com/HornsAndHooves/flat_map/pull/11
* Relates to https://github.com/HornsAndHooves/moribus/pull/20